### PR TITLE
Chore: Auto-detect service api key or user token

### DIFF
--- a/src/AyonCppApi/AyonCppApi.cpp
+++ b/src/AyonCppApi/AyonCppApi.cpp
@@ -193,10 +193,13 @@ AyonApi::AyonApi(const std::optional<std::string> &logFilePos,
         // - if fails use it as user tokens
         m_headers = {
             {"X-Api-Key", m_authKey},
+            {"X-ayon-site-id", m_siteId},
         };
         auto res = m_AyonServer->Get("/api/users/me", m_headers);
         if (res->status != 200) {
-            m_headers = {};
+            m_headers = {
+                {"X-ayon-site-id", m_siteId},
+            };
             m_AyonServer->set_bearer_token_auth(m_authKey);
         }
     }
@@ -403,7 +406,8 @@ AyonApi::resolvePath(const std::string &uriPath) {
     }
     std::pair<std::string, std::string> resolvedAsset;
     nlohmann::json jsonPayload = {{"resolveRoots", false}, {"uris", nlohmann::json::array({uriPath})}};
-    httplib::Headers headers = {{"X-ayon-site-id", m_siteId}};
+    httplib::Headers headers = m_headers;
+
     uint8_t sucsessStatus = 200;
 
     nlohmann::json response
@@ -443,7 +447,7 @@ AyonApi::batchResolvePath(std::vector<std::string> &uriPaths) {
     std::vector<std::future<nlohmann::json>> futures;
 
     std::shared_ptr<httplib::Headers> headers
-        = std::make_shared<httplib::Headers>(httplib::Headers{{"X-ayon-site-id", m_siteId}});
+        = std::make_shared<httplib::Headers>(m_headers);
 
     std::shared_ptr<std::string> batchResolveEndpoint;
     if (m_pathOnlyReselution) {

--- a/src/AyonCppApi/AyonCppApi.cpp
+++ b/src/AyonCppApi/AyonCppApi.cpp
@@ -139,10 +139,6 @@ AyonApi::AyonApi(const std::optional<std::string> &logFilePos,
     m_AyonServer = std::make_unique<httplib::Client>(m_serverUrl);
 
     if (isSSL()) {
-        m_headers = {
-            {"X-Api-Key", m_authKey},
-        };
-
         try {
             std::string opensslDirCLI = getOpenSSLDirByCLI();
 
@@ -186,18 +182,23 @@ AyonApi::AyonApi(const std::optional<std::string> &logFilePos,
         }
 
         m_AyonServer->enable_server_certificate_verification(true);
-    } else {
-        m_AyonServer->set_bearer_token_auth(m_authKey);
-        m_headers = {};
     }
 
-    auto res = m_AyonServer->Get("/api/info", m_headers);
+    auto res = m_AyonServer->Get("/api/info");
     if (!res) {
         m_Log->error("Failed to connect to the Ayon server.");
-    } else if (res->status != 200) {
-        m_Log->warn("Connected to the Ayon server : {}", res->status);
     } else {
         m_Log->info("Connected to the Ayon server : {}", res->status);
+        // First try to use authentication token as service API key
+        // - if fails use it as user tokens
+        m_headers = {
+            {"X-Api-Key", m_authKey},
+        };
+        auto res = m_AyonServer->Get("/api/users/me", m_headers);
+        if (res->status != 200) {
+            m_headers = {};
+            m_AyonServer->set_bearer_token_auth(m_authKey);
+        }
     }
 
     m_Log->info(m_Log->key("AyonApi"), "Constructor Getting Site Roots");

--- a/src/AyonCppApi/AyonCppApi.cpp
+++ b/src/AyonCppApi/AyonCppApi.cpp
@@ -193,13 +193,10 @@ AyonApi::AyonApi(const std::optional<std::string> &logFilePos,
         // - if fails use it as user tokens
         m_headers = {
             {"X-Api-Key", m_authKey},
-            {"X-ayon-site-id", m_siteId},
         };
         auto res = m_AyonServer->Get("/api/users/me", m_headers);
         if (res->status != 200) {
-            m_headers = {
-                {"X-ayon-site-id", m_siteId},
-            };
+            m_headers = {};
             m_AyonServer->set_bearer_token_auth(m_authKey);
         }
     }
@@ -407,6 +404,7 @@ AyonApi::resolvePath(const std::string &uriPath) {
     std::pair<std::string, std::string> resolvedAsset;
     nlohmann::json jsonPayload = {{"resolveRoots", false}, {"uris", nlohmann::json::array({uriPath})}};
     httplib::Headers headers = m_headers;
+    headers.insert({"X-ayon-site-id", m_siteId});
 
     uint8_t sucsessStatus = 200;
 


### PR DESCRIPTION
## Changelog Description
Auto-detect if authentication token is service api key or user's token.

## Testing notes:
1. Both service api key and user token can be used with CPP api.
