### PR TITLE
Add extra validation check

### DIFF
--- a/src/AyonCppApi/AyonCppApi.cpp
+++ b/src/AyonCppApi/AyonCppApi.cpp
@@ -109,7 +109,7 @@ AyonApi::AyonApi(const std::optional<std::string> &logFilePos,
 
     // ----------- Resolve Log Path
     std::filesystem::path logPath;
-    if (logFilePos.has_value()) {
+    if (logFilePos && !logFilePos->empty()) {
         try {
             std::filesystem::path inPath(logFilePos.value());
             std::cout << "Input log path: " << inPath << std::endl;

--- a/src/AyonCppApi/AyonCppApi.cpp
+++ b/src/AyonCppApi/AyonCppApi.cpp
@@ -149,7 +149,7 @@ AyonApi::AyonApi(const std::optional<std::string> &logFilePos,
 
     m_log = std::shared_ptr<AyonLogger>(&loggerRef, [](AyonLogger*){});
     m_log->registerLoggingKey("AyonApi");
-    m_log->setLogLevelInfo();
+    m_log->setLogLevelFromEnv();
     m_log->info(m_log->key("AyonApi"), "Init AyonServer httplib::Client");
     
     m_ayonServer = std::make_unique<httplib::Client>(m_serverUrl);


### PR DESCRIPTION
## Changelog Description
This pull request makes a small but important improvement to the constructor of the `AyonApi` class. The change ensures that the log file path is only processed if the optional string is both present and non-empty, adding a more robust check for valid input.

## Additional review information
* Improved input validation in the `AyonApi` constructor by checking that `logFilePos` is not only set but also non-empty before using it.

## Testing notes:
Tested already with [this PR](https://github.com/ynput/ayon-usd-resolver/pull/70).
