### PR TITLE
Release 0.1.3 prep

### DIFF
--- a/src/AyonCppApi/AyonCppApi.cpp
+++ b/src/AyonCppApi/AyonCppApi.cpp
@@ -109,7 +109,7 @@ AyonApi::AyonApi(const std::optional<std::string> &logFilePos,
 
     // ----------- Resolve Log Path
     std::filesystem::path logPath;
-    if (logFilePos.has_value()) {
+    if (logFilePos && !logFilePos->empty()) {
         try {
             std::filesystem::path inPath(logFilePos.value());
             std::cout << "Input log path: " << inPath << std::endl;

--- a/src/AyonCppApi/AyonCppApi.cpp
+++ b/src/AyonCppApi/AyonCppApi.cpp
@@ -149,7 +149,7 @@ AyonApi::AyonApi(const std::optional<std::string> &logFilePos,
 
     m_log = std::shared_ptr<AyonLogger>(&loggerRef, [](AyonLogger*){});
     m_log->registerLoggingKey("AyonApi");
-    m_log->setLogLevelInfo();
+    m_log->setLogLevelFromEnv();
     m_log->info(m_log->key("AyonApi"), "Init AyonServer httplib::Client");
     
     m_ayonServer = std::make_unique<httplib::Client>(m_serverUrl);


### PR DESCRIPTION
## Changelog Description
This pull request updates the logging behavior in the `AyonApi` constructor and updates the `ayon-cpp-dev-tools` submodule. The changes ensure that the log file path is only used if it is both present and non-empty, and that the log level is now set from an environment variable rather than being hardcoded.

**Logging improvements:**
* Updated the log file path check to ensure it is both present and non-empty before using it. (`src/AyonCppApi/AyonCppApi.cpp`)
* Changed logger initialization to set the log level from the environment variable instead of always setting it to "info". (`src/AyonCppApi/AyonCppApi.cpp`)

**Submodule update:**
* Updated the `ayon-cpp-dev-tools` submodule to a new commit. (`ext/ayon-cpp-dev-tools`)

## Testing notes:
Tested already before merging to develop.